### PR TITLE
Add Dockerfile for building static assets for frontend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.idea
+.vscode
+build/
+node_modules/
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+#intellij
+.idea/
+
 # dependencies
 /node_modules
 /.pnp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:lts AS frontend
+
+WORKDIR /frontend
+COPY . .
+RUN yarn
+RUN yarn build
+
+FROM alpine:latest
+WORKDIR /frontend
+COPY --from=frontend /frontend/build /frontend

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@osiris/frontend",
   "version": "0.1.0",
   "private": true,
+  "homepage": "/app",
   "dependencies": {
     "@material-ui/core": "^4.4.3",
     "@material-ui/icons": "^4.4.3",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/styles';
 import theme from './utils/theme';
-import { BrowserRouter as Router } from "react-router-dom";
+import { HashRouter as Router } from "react-router-dom";
 import { App } from './App';
 
 ReactDOM.render(


### PR DESCRIPTION
These changes make the Dockerfile build the static assets, then copies them to a tiny alpine image which is then published at `nicholastmosher/ifad-frontend:latest`. This image is a dependency of the backend image, which then serves the assets on the express server.