### PR TITLE
Update interaction with wgs_segments API call

### DIFF
--- a/src/components/WGS/store.ts
+++ b/src/components/WGS/store.ts
@@ -38,11 +38,11 @@ export const withPieChartData = (filters: IPieChartFilter[] = [], mode: FilterMo
                         [aspect]: [
                             {
                                 name: "EXP",
-                                value: info.known.exp,
+                                value: info.knownExp,
                             },
                             {
                                 name: "OTHER",
-                                value: info.known.other,
+                                value: info.knownOther,
                             },
                             {
                                 name: "UNKNOWN",


### PR DESCRIPTION
Updates to match the recent change in the API response from the `wgs_segments` endpoint:

Previously:
```ts
{
  all: number,
  unknown: number,
  unannotated: number,
  known: {
    all: number,
    exp: number,
    other: number,
  },
  totalGenes: number,
}
```

Now:
```ts
{
  all: number,
  unknown: number,
  unannotated: number,
  knownAll: number,
  knownExp: number,
  knownOther: number,
  totalGenes: number,
}
```